### PR TITLE
core/qt/sdl: Remove dangerous API URL setting

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -468,7 +468,6 @@ struct Values {
 
     // WebService
     bool enable_telemetry;
-    std::string web_api_url;
     std::string yuzu_username;
     std::string yuzu_token;
 

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -25,6 +25,8 @@
 
 namespace Core {
 
+constexpr char WEB_API_URL[] = "https://api.yuzu-emu.org";
+
 static u64 GenerateTelemetryId() {
     u64 telemetry_id{};
 
@@ -104,7 +106,7 @@ u64 RegenerateTelemetryId() {
 
 bool VerifyLogin(const std::string& username, const std::string& token) {
 #ifdef ENABLE_WEB_SERVICE
-    return WebService::VerifyLogin(Settings::values.web_api_url, username, token);
+    return WebService::VerifyLogin(WEB_API_URL, username, token);
 #else
     return false;
 #endif
@@ -121,7 +123,7 @@ TelemetrySession::~TelemetrySession() {
 
 #ifdef ENABLE_WEB_SERVICE
     auto backend = std::make_unique<WebService::TelemetryJson>(
-        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
+        WEB_API_URL, Settings::values.yuzu_username, Settings::values.yuzu_token);
 #else
     auto backend = std::make_unique<Telemetry::NullVisitor>();
 #endif
@@ -195,7 +197,7 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
 bool TelemetrySession::SubmitTestcase() {
 #ifdef ENABLE_WEB_SERVICE
     auto backend = std::make_unique<WebService::TelemetryJson>(
-        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
+        WEB_API_URL, Settings::values.yuzu_username, Settings::values.yuzu_token);
     field_collection.Accept(*backend);
     return backend->SubmitTestcase();
 #else

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -776,10 +776,6 @@ void Config::ReadWebServiceValues() {
 
     Settings::values.enable_telemetry =
         ReadSetting(QStringLiteral("enable_telemetry"), true).toBool();
-    Settings::values.web_api_url =
-        ReadSetting(QStringLiteral("web_api_url"), QStringLiteral("https://api.yuzu-emu.org"))
-            .toString()
-            .toStdString();
     Settings::values.yuzu_username =
         ReadSetting(QStringLiteral("yuzu_username")).toString().toStdString();
     Settings::values.yuzu_token =
@@ -1190,9 +1186,6 @@ void Config::SaveWebServiceValues() {
     qt_config->beginGroup(QStringLiteral("WebService"));
 
     WriteSetting(QStringLiteral("enable_telemetry"), Settings::values.enable_telemetry, true);
-    WriteSetting(QStringLiteral("web_api_url"),
-                 QString::fromStdString(Settings::values.web_api_url),
-                 QStringLiteral("https://api.yuzu-emu.org"));
     WriteSetting(QStringLiteral("yuzu_username"),
                  QString::fromStdString(Settings::values.yuzu_username));
     WriteSetting(QStringLiteral("yuzu_token"), QString::fromStdString(Settings::values.yuzu_token));

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -444,8 +444,6 @@ void Config::ReadValues() {
     // Web Service
     Settings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.web_api_url =
-        sdl2_config->Get("WebService", "web_api_url", "https://api.yuzu-emu.org");
     Settings::values.yuzu_username = sdl2_config->Get("WebService", "yuzu_username", "");
     Settings::values.yuzu_token = sdl2_config->Get("WebService", "yuzu_token", "");
 

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -172,8 +172,6 @@ void Config::ReadValues() {
     // Web Service
     Settings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.web_api_url =
-        sdl2_config->Get("WebService", "web_api_url", "https://api.yuzu-emu.org");
     Settings::values.yuzu_username = sdl2_config->Get("WebService", "yuzu_username", "");
     Settings::values.yuzu_token = sdl2_config->Get("WebService", "yuzu_token", "");
 }


### PR DESCRIPTION
This setting allows users to change the URL of the backend core API (responsible for gamedb, telemetry, testcases, amongst others). This is extemely dangerous to have as a configuration setting because a malicious actor could distribute custom configuration packages with a custom API URL, and use this setup to collect user tokens, which can be used to impersonate users on the core API, which is catastrophic.

This flaw was recently discovered in a backend meeting.